### PR TITLE
Added the missing permission parameter for the bot invite URL

### DIFF
--- a/bot.rb
+++ b/bot.rb
@@ -39,7 +39,7 @@ bot = Discordrb::Commands::CommandBot.new(
 )
 bot.include! MamiTheSpoilerBot
 
-puts "[INFO] This bot's invite URL is #{bot.invite_url}."
+puts "[INFO] This bot's invite URL is #{bot.invite_url(permission_bits: 8192)}."
 puts '[INFO] Click on it to invite it to your server.'
 
 bot.run


### PR DESCRIPTION
The permission parameter was missing, but mami-bot needs the permission "manage messages" for working correctly.

Thus, the bot's invite URL given in the console is valid.